### PR TITLE
Enable verifying signatures from WASM

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,13 @@ repository = "https://github.com/jedisct1/rust-minisign-verify"
 categories = ["cryptography"]
 edition = "2018"
 
+[lib]
+crate-type = ["cdylib", "rlib"]
+
 [profile.release]
 lto = true
 panic = "abort"
 opt-level = 3
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+wasm-bindgen = "0.2"


### PR DESCRIPTION
This PR exports a single function `verify_signature` using only wasm-bindgen-compatible types so that this library can be compiled to WASM and used from JavaScript/TypeScript.

The changes will only be included if compiling for a wasm32 target. The only exception to this is that the crate-type is now explicitly declared as `["cdylib", "rlib"]` instead of the implicit `["lib"]`.