### PR TITLE
stream update hash

### DIFF
--- a/src/crypto/blake2b.rs
+++ b/src/crypto/blake2b.rs
@@ -223,7 +223,7 @@ impl Blake2b {
         }
     }
 
-    fn update(&mut self, mut input: &[u8]) {
+    pub fn update(&mut self, mut input: &[u8]) {
         while !input.is_empty() {
             let left = self.buflen;
             let fill = 2 * BLAKE2B_BLOCKBYTES - left;
@@ -250,7 +250,7 @@ impl Blake2b {
         }
     }
 
-    fn finalize(&mut self, out: &mut [u8]) {
+    pub fn finalize(&mut self, out: &mut [u8]) {
         assert!(out.len() == self.digest_length as usize);
         if !self.computed {
             if self.buflen > BLAKE2B_BLOCKBYTES {


### PR DESCRIPTION
Hi Frank :wave: 

Here's a PR where I added a new PublicKeyStream type that supports streaming data to the internal blake2 hasher directly. This is beneficial in situations where the data is processed on the fly and then discarded (e.g. a stream that gets decompressed to disk on the go). 

The full blown minisign-rust library supports that through the [verify reader interface](https://docs.rs/minisign/latest/minisign/fn.verify.html#), but this thin client lacked support.

Keep me posted what you think :) 
Cheers !